### PR TITLE
fix(background): correct `isConnected` behavior

### DIFF
--- a/background/src/api/graphql.ts
+++ b/background/src/api/graphql.ts
@@ -23,9 +23,7 @@ async function getLastBlockIndex(endpoint: string) {
                 }
                 `,
 		}),
-		headers: [
-			['content-type', 'application/json']
-		]
+		headers: [["content-type", "application/json"]],
 	});
 
 	const data = await response.json();
@@ -92,7 +90,7 @@ export default class Graphql {
 				const result = await fn(endpoint);
 				return result;
 			} catch (e) {
-				console.error('e', e);
+				console.error("e", e);
 				exceptions.push(e);
 			}
 		}
@@ -120,9 +118,7 @@ export default class Graphql {
                   }
                 `,
 				}),
-				headers: [
-					['content-type', 'application/json']
-				]
+				headers: [["content-type", "application/json"]],
 			});
 
 			const data = await response.json();
@@ -143,9 +139,7 @@ export default class Graphql {
                   }
                 `,
 				}),
-				headers: [
-					['content-type', 'application/json']
-				]
+				headers: [["content-type", "application/json"]],
 			});
 
 			const data = await response.json();
@@ -168,9 +162,7 @@ export default class Graphql {
                       }
                     `,
 				}),
-				headers: [
-					['content-type', 'application/json']
-				]
+				headers: [["content-type", "application/json"]],
 			});
 			const data = await response.json();
 			return { txId: data["data"]["stageTransaction"], endpoint };
@@ -192,9 +184,7 @@ export default class Graphql {
                     }
                 `,
 			}),
-			headers: [
-				['content-type', 'application/json']
-			]
+			headers: [["content-type", "application/json"]],
 		});
 		const data = await response.json();
 		return data["data"]["transaction"]["transactionResult"]["txStatus"];

--- a/background/src/controllers/connection.ts
+++ b/background/src/controllers/connection.ts
@@ -15,12 +15,17 @@ export class ConnectionController {
         await this.setConnections(connections);
 	}
 
-	async isConnected(origin: string, address?: Address): Promise<boolean> {
+	async isConnectedSite(origin: string): Promise<boolean> {
 		const connections = await this.getConnections();
-		if (!connections.hasOwnProperty(origin)) {
-            return false;
-        }
+		return connections.hasOwnProperty(origin);
+	}
 
+	async isConnected(origin: string, address: Address): Promise<boolean> {
+		if (!this.isConnectedSite(origin)) {
+			return false;
+		}
+
+		const connections = await this.getConnections();
         const connectedAddresses = connections[origin];
         return connectedAddresses.find(x => x === address.toString()) !== undefined
 	}

--- a/background/src/controllers/connection.ts
+++ b/background/src/controllers/connection.ts
@@ -5,14 +5,12 @@ import { Address } from "@planetarium/account";
 type Connections = Record<string, string[]>;
 
 export class ConnectionController {
-	constructor(
-		private readonly storage: IStorage,
-	) {}
+	constructor(private readonly storage: IStorage) {}
 
 	async connect(origin: string, addresses: Address[]): Promise<void> {
-        const connections = await this.getConnections();
-        connections[origin] = addresses.map(x => x.toString());
-        await this.setConnections(connections);
+		const connections = await this.getConnections();
+		connections[origin] = addresses.map((x) => x.toString());
+		await this.setConnections(connections);
 	}
 
 	async isConnectedSite(origin: string): Promise<boolean> {
@@ -26,8 +24,10 @@ export class ConnectionController {
 		}
 
 		const connections = await this.getConnections();
-        const connectedAddresses = connections[origin];
-        return connectedAddresses.find(x => x === address.toString()) !== undefined
+		const connectedAddresses = connections[origin];
+		return (
+			connectedAddresses.find((x) => x === address.toString()) !== undefined
+		);
 	}
 
 	async getConnections(): Promise<Connections> {

--- a/background/src/storage/backend/common.ts
+++ b/background/src/storage/backend/common.ts
@@ -1,4 +1,4 @@
 export interface IStorageBackend {
-    get<T>(key: string): Promise<T | null>;
-    set<T>(key: string, value: T): Promise<void>;
+	get<T>(key: string): Promise<T | null>;
+	set<T>(key: string, value: T): Promise<void>;
 }

--- a/background/src/storage/backend/local-storage.ts
+++ b/background/src/storage/backend/local-storage.ts
@@ -1,7 +1,7 @@
 import { IStorageBackend } from "./common.js";
 
 export class LocalStorageBackend implements IStorageBackend {
-    set<T>(name: string, value: T): Promise<void> {
+	set<T>(name: string, value: T): Promise<void> {
 		return chrome.storage.local.set({ [name]: value });
 	}
 

--- a/background/src/wallet/wallet.ts
+++ b/background/src/wallet/wallet.ts
@@ -333,7 +333,7 @@ export default class Wallet {
 	}
 
 	async isConnected(): Promise<boolean> {
-		return this.connectionController.isConnected(this.origin);
+		return this.connectionController.isConnectedSite(this.origin);
 	}
 
 	async listAccounts(): Promise<Account[]> {

--- a/background/src/wallet/wallet.ts
+++ b/background/src/wallet/wallet.ts
@@ -16,7 +16,12 @@ import {
 } from "@planetarium/bencodex";
 import * as ethers from "ethers";
 import { Address } from "@planetarium/account";
-import { UnsignedTx, encodeSignedTx, encodeUnsignedTx, signTx } from "@planetarium/tx";
+import {
+	UnsignedTx,
+	encodeSignedTx,
+	encodeUnsignedTx,
+	signTx,
+} from "@planetarium/tx";
 import { Lazyable, resolve } from "../utils/lazy";
 import { Emitter } from "../event";
 import { Buffer } from "buffer";
@@ -199,7 +204,9 @@ export default class Wallet {
 		};
 
 		const signedTx = await signTx(unsignedTx, account);
-		const encodedHex = Buffer.from(encode(encodeSignedTx(signedTx))).toString("hex");
+		const encodedHex = Buffer.from(encode(encodeSignedTx(signedTx))).toString(
+			"hex",
+		);
 		const { txId, endpoint } = await this.api.stageTx(encodedHex);
 
 		return { txId, endpoint };
@@ -326,7 +333,10 @@ export default class Wallet {
 				data: { origin: this.origin },
 			})
 			.then(async (metadata: string[]) => {
-				await this.connectionController.connect(this.origin, metadata.map(x => Address.fromHex(x, true)))
+				await this.connectionController.connect(
+					this.origin,
+					metadata.map((x) => Address.fromHex(x, true)),
+				);
 				this.emitter("connected", metadata);
 				return metadata;
 			});
@@ -339,11 +349,16 @@ export default class Wallet {
 	async listAccounts(): Promise<Account[]> {
 		const accounts = await this.storage.get<Account[]>(ACCOUNTS);
 		if (this.origin) {
-			const checked: [boolean, Account][] = await Promise.all(accounts.map(
-				async (x) =>
-					[await this.connectionController.isConnected(this.origin, Address.fromHex(x.address)), x]
-			));
-			return checked.filter(x => x[0]).map(x => x[1]);
+			const checked: [boolean, Account][] = await Promise.all(
+				accounts.map(async (x) => [
+					await this.connectionController.isConnected(
+						this.origin,
+						Address.fromHex(x.address),
+					),
+					x,
+				]),
+			);
+			return checked.filter((x) => x[0]).map((x) => x[1]);
 		}
 
 		console.log(accounts);


### PR DESCRIPTION
This pull request fixes a bug where `Wallet.isConnected` doesn't work well. For this change, you should see [3eb0ee7](https://github.com/planetarium/chrono/pull/110/commits/3eb0ee7d71bf8c016afee07cad5bf96d9dcf8acf). [bdca89c](https://github.com/planetarium/chrono/pull/110/commits/bdca89cbbd9599944a7f328702a5de816b5308c1) commit just runs `pnpm fmt` (biome lint).